### PR TITLE
Fix little issue setting SLI with highest stddev

### DIFF
--- a/prototype_parse.py
+++ b/prototype_parse.py
@@ -133,7 +133,7 @@ def parse_luo2009_supplemental_file_S3(path, symbol2entrezID):
             if geneB_sym in sli_dict:
                 # get the entry with the strongest effect size
                 sli_b = sli_dict.get(geneB_sym)
-                if abs(stddev) > abs(sli.effect_size):
+                if abs(stddev) > abs(sli_b.effect_size):
                     sli_dict[geneB_sym] = sli
             else:
                 # first entry for geneB


### PR DESCRIPTION
Minor fix, I think [this line](https://github.com/deepakunni3/IDGKG-gen/blob/59addd39e52216aaece9905494f32d526d8d009d/prototype_parse.py#L136) should be:
`                if abs(stddev) > abs(sli_b.effect_size):`
